### PR TITLE
Fix/mimetype default

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function uploadFile(filePath, bucketName, localDir, client, cli) {
       Key: cleanFilePathOfLocalDir(filePath, localDir),
       Bucket: bucketName,
       Body: fs.createReadStream(filePath),
-      ContentType: mime.lookup(filePath),
+      ContentType: mime.lookup(filePath) || 'application/octet-stream',
     };
     cli.consoleLog(`${messagePrefix} Uploading.. ${params.Key}`);
     client.upload(params, (err) => {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ class ServerlessS3LocalSync {
       'before:offline:start:init': this.sync.bind(this),
       'before:offline:start': this.sync.bind(this),
     };
-
   }
 
   sync() {
@@ -80,9 +79,9 @@ class ServerlessS3LocalSync {
     this.s3 = this.serverless.service.custom.s3 || {};
     this.s3.port = this.s3.port || 5000;
     this.client = new AWS.S3({
-	    s3ForcePathStyle: true,
-	    endpoint: new AWS.Endpoint(`http://localhost:${this.s3.port}`),
-				       });
+      s3ForcePathStyle: true,
+      endpoint: new AWS.Endpoint(`http://localhost:${this.s3.port}`),
+    });
 
     cli.consoleLog(`${messagePrefix} Sync using port: ${this.s3.port} + ${this.servicePath}`);
 


### PR DESCRIPTION
When running the sync and there is a file that does not return a proper mime_type we should fallback to 'application/octet-stream' (suggested by [mime-types](https://github.com/jshttp/mime-types) library)

