### PR TITLE
allow the setting of the s3 server host

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,9 +78,10 @@ class ServerlessS3LocalSync {
 
     this.s3 = this.serverless.service.custom.s3 || {};
     this.s3.port = this.s3.port || 5000;
+    this.s3.host = this.s3.host || 'localhost';
     this.client = new AWS.S3({
       s3ForcePathStyle: true,
-      endpoint: new AWS.Endpoint(`http://localhost:${this.s3.port}`),
+      endpoint: new AWS.Endpoint(`http://${this.s3.host}:${this.s3.port}`),
       accessKeyId: 'S3RVER',
       secretAccessKey: 'S3RVER',
     });


### PR DESCRIPTION
In the readme file you current show an option for `host` but it was not supported in the code.  I am running s3rver in a docker container with docker-compose so it was critical to be able to support this.